### PR TITLE
Stripe Connected Customer & Card Sync

### DIFF
--- a/lib/generators/active_record/pay_generator.rb
+++ b/lib/generators/active_record/pay_generator.rb
@@ -40,6 +40,7 @@ module ActiveRecord
       t.string :card_last4
       t.string :card_exp_month
       t.string :card_exp_year
+      t.string :marketplace_id
       t.text :extra_billing_info
 RUBY
       end

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -24,6 +24,7 @@ module Pay
       attribute :plan, :string
       attribute :quantity, :integer
       attribute :card_token, :string
+      attribute :marketplace_id, :string
       attribute :pay_fake_processor_allowed, :boolean, default: false
 
       validate :pay_fake_processor_is_allowed, if: :processor_changed?

--- a/test/vcr_cassettes/test_getting_a_connected_stripe_customer.yml
+++ b/test/vcr_cassettes/test_getting_a_connected_stripe_customer.yml
@@ -1,0 +1,481 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: email=johnny%40appleseed.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/5.22.0
+      Authorization:
+      - Bearer sk_test_NvqUxbuIshb0DGNWK5rAbRNC
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_RMNkhjCJFXooFO","request_duration_ms":4}}'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"5.22.0","lang":"ruby","lang_version":"2.7.1 p83 (2020-03-31)","platform":"x86_64-darwin19","engine":"ruby","publisher":"stripe","uname":"Darwin
+        MacBook-Pro.local 19.5.0 Darwin Kernel Version 19.5.0: Tue May 26 20:41:44
+        PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64","hostname":"MacBook-Pro.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 12 Jul 2020 21:43:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1088'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_1VXzebvqjYI1WR
+      Stripe-Version:
+      - '2020-03-02'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_HdTvL7xXm78Dv4",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1594590203,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "johnny@appleseed.com",
+          "invoice_prefix": "C38CD08E",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvL7xXm78Dv4/sources"
+          },
+          "subscriptions": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvL7xXm78Dv4/subscriptions"
+          },
+          "tax_exempt": "none",
+          "tax_ids": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvL7xXm78Dv4/tax_ids"
+          }
+        }
+  recorded_at: Sun, 12 Jul 2020 21:43:23 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: country=US&type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/5.22.0
+      Authorization:
+      - Bearer sk_test_NvqUxbuIshb0DGNWK5rAbRNC
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_1VXzebvqjYI1WR","request_duration_ms":398}}'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"5.22.0","lang":"ruby","lang_version":"2.7.1 p83 (2020-03-31)","platform":"x86_64-darwin19","engine":"ruby","publisher":"stripe","uname":"Darwin
+        MacBook-Pro.local 19.5.0 Darwin Kernel Version 19.5.0: Tue May 26 20:41:44
+        PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64","hostname":"MacBook-Pro.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 12 Jul 2020 21:43:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2388'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tzuwHXeILpUxE
+      Stripe-Version:
+      - '2020-03-02'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "acct_1H4CxDIOAmfDwGX3",
+          "object": "account",
+          "business_profile": {
+            "mcc": "7372",
+            "name": null,
+            "product_description": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": null
+          },
+          "business_type": null,
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "inactive"
+          },
+          "charges_enabled": false,
+          "country": "US",
+          "created": 1594590204,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1H4CxDIOAmfDwGX3/external_accounts"
+          },
+          "metadata": {
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.url",
+              "business_type",
+              "external_account",
+              "relationship.representative",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [
+
+            ],
+            "eventually_due": [
+              "business_profile.url",
+              "business_type",
+              "external_account",
+              "relationship.representative",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "past_due": [
+              "business_profile.url",
+              "business_type",
+              "external_account",
+              "relationship.representative",
+              "tos_acceptance.date",
+              "tos_acceptance.ip"
+            ],
+            "pending_verification": [
+
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": null
+            },
+            "dashboard": {
+              "display_name": null,
+              "timezone": "Etc/UTC"
+            },
+            "payments": {
+              "statement_descriptor": "",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            }
+          },
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Sun, 12 Jul 2020 21:43:24 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: email=johnny%40appleseed.com
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/5.22.0
+      Authorization:
+      - Bearer sk_test_NvqUxbuIshb0DGNWK5rAbRNC
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8tzuwHXeILpUxE","request_duration_ms":1253}}'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"5.22.0","lang":"ruby","lang_version":"2.7.1 p83 (2020-03-31)","platform":"x86_64-darwin19","engine":"ruby","publisher":"stripe","uname":"Darwin
+        MacBook-Pro.local 19.5.0 Darwin Kernel Version 19.5.0: Tue May 26 20:41:44
+        PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64","hostname":"MacBook-Pro.local"}'
+      Stripe-Account:
+      - acct_1H4CxDIOAmfDwGX3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 12 Jul 2020 21:43:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1088'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_PIaNaUeL3mbKGk
+      Stripe-Account:
+      - acct_1H4CxDIOAmfDwGX3
+      Stripe-Version:
+      - '2020-03-02'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_HdTvmxnSZVEKLE",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1594590205,
+          "currency": null,
+          "default_source": null,
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": "johnny@appleseed.com",
+          "invoice_prefix": "0773DF7D",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvmxnSZVEKLE/sources"
+          },
+          "subscriptions": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvmxnSZVEKLE/subscriptions"
+          },
+          "tax_exempt": "none",
+          "tax_ids": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/customers/cus_HdTvmxnSZVEKLE/tax_ids"
+          }
+        }
+  recorded_at: Sun, 12 Jul 2020 21:43:25 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/plans/small-monthly
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/5.22.0
+      Authorization:
+      - Bearer sk_test_NvqUxbuIshb0DGNWK5rAbRNC
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PIaNaUeL3mbKGk","request_duration_ms":409}}'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"5.22.0","lang":"ruby","lang_version":"2.7.1 p83 (2020-03-31)","platform":"x86_64-darwin19","engine":"ruby","publisher":"stripe","uname":"Darwin
+        MacBook-Pro.local 19.5.0 Darwin Kernel Version 19.5.0: Tue May 26 20:41:44
+        PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64","hostname":"MacBook-Pro.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 12 Jul 2020 21:43:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '227'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_FJgGiPzEvrniFk
+      Stripe-Version:
+      - '2020-03-02'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "resource_missing",
+            "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
+            "message": "No such plan: small-monthly",
+            "param": "plan",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Sun, 12 Jul 2020 21:43:25 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Applications that enable Stripe Connect, allow businesses to collect
payments on their platform. This generates "connected" accounts within
the platform account, scoping customers and payment methods to that
account.

Allow Pay to correctly retrieve connected customer and payment methods
when syncing data via webhooks by passing the connected account id as the
`stripe_account` option.